### PR TITLE
Fix flutter sdk constraint

### DIFF
--- a/packages/remote_ui/pubspec.yaml
+++ b/packages/remote_ui/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/jaumard/remote_ui/tree/master/packages/remote_ui
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter_sdk: ">=2.0.0 <3.0.0"
+  flutter: ">=2.0.0 <3.0.0"
 
 dependencies:
   flutter_hooks: ">=0.18.0 <1.0.0"


### PR DESCRIPTION
This should enable package analysis on pub.dev that is currently broken (see: https://pub.dev/packages/remote_ui/versions and https://pub.dev/documentation/remote_ui/latest/log.txt)